### PR TITLE
Fix XML version in tcx/gpx export

### DIFF
--- a/src/site/export.js
+++ b/src/site/export.js
@@ -31,7 +31,7 @@ sauce.ns('export', function() {
         }
 
         toFile() {
-            const heading = `<?xml version="${this.doc.xmlVersion}" encoding="${this.doc.inputEncoding}"?>\n`;
+            const heading = `<?xml version="1.0" encoding="${this.doc.inputEncoding}"?>\n`;
             return new File(
                 [heading + (new XMLSerializer()).serializeToString(this.doc)],
                 `${this.activity.name}.${this.fileExt}`.replace(/\s/g, '_'),


### PR DESCRIPTION
When exporting to tcx/gpx, I was getting `version="undefined"` in the XML header (using Firefox). According to https://developer.mozilla.org/en-US/docs/Web/API/Document/xmlVersion `Document.xmlVersion` is obsolete (and is not supported by firefox).

I have fixed this by setting it to `1.0` as this is what it should always be anyway.