### PR TITLE
Add TotalTimeSeconds element to tcx export format

### DIFF
--- a/src/site/export.js
+++ b/src/site/export.js
@@ -157,14 +157,20 @@ sauce.ns('export', function() {
             this.addNodeTo(creator, 'UnitId', 0);
             this.addNodeTo(creator, 'ProductId', 0);
             creator.appendChild(sauceVersion.cloneNode(/*deep*/ true));
-            const lap = this.addNodeTo(activity, 'Lap');
-            lap.setAttribute('StartTime', startISOString);
-            this.addNodeTo(lap, 'TriggerMethod', 'Manual');
-            this.track = this.addNodeTo(lap, 'Track');
+            this.lap = this.addNodeTo(activity, 'Lap');
+            this.lap.setAttribute('StartTime', startISOString);
+            this.addNodeTo(this.lap, 'TriggerMethod', 'Manual');
+            this.track = this.addNodeTo(this.lap, 'Track');
         }
 
         loadStreams(streams) {
             const startTime = this.activity.start.getTime();
+            if (streams.time.length > 0) {
+                var endTime = startTime + (streams.time[streams.time.length - 1] * 1000);
+                this.addNodeTo(this.lap, 'TotalTimeSeconds', (endTime - startTime) / 1000);
+            } else {
+                this.addNodeTo(this.lap, 'TotalTimeSeconds', 0);
+            }
             for (let i = 0; i < streams.time.length; i++) {
                 const point = this.addNodeTo(this.track, 'Trackpoint');
                 const t = (new Date(startTime + (streams.time[i] * 1000)));


### PR DESCRIPTION
This adds a `TotalTimeSeconds` node to the `Lap` node. when generating a tcx file.

I was trying to import a tcx file generated by sauce4strava with [sports-alliance/sports-lib](https://github.com/sports-alliance/sports-lib) and was getting errors due to this missing element. I understand the tcx export is a beta feature and there are other missing elements, but adding this element at least allows us to import using the sports-lib library which now accepts the file.