### PR TITLE
Avoid Perf Predictor crashing if rider has no weight

### DIFF
--- a/src/site/analysis.js
+++ b/src/site/analysis.js
@@ -2876,7 +2876,7 @@ sauce.ns('analysis', ns => {
             power: power && Math.round(power),
             hasWeight: !!ns.weight,
             wkg: power && ns.weight && H.number(power / ns.weight, {fixed: true, precision: 1}),
-            bodyWeight: L.weightFormatter.convert(ns.weight).toFixed(1),
+            bodyWeight: ns.weight && L.weightFormatter.convert(ns.weight).toFixed(1),
             gearWeight: L.weightFormatter.convert(bikeDefaults.gearWeight).toFixed(1),
             slope: (slope * 100).toFixed(1),
             distance: L.distanceFormatter.convert(origDistance).toFixed(3),


### PR DESCRIPTION
Check if ns.weight exists before converting, otherwise we will get a type error for trying to run `toFixed(1)` on `undefined`.

Cheers!

To test:

* Go to https://www.strava.com/activities/1537067643#38485981109 and click Perf Predictor on any segment.
* Nothing happens, except an error in the console.
* When switching to the dev version with the fix below applied, the Perf Predictor shows up with weight field empty, but at least it shows up.