### PR TITLE
Add tooltip to Activty Sync button

### DIFF
--- a/templates/sync-button.html
+++ b/templates/sync-button.html
@@ -1,4 +1,4 @@
-<div class="btn sauce-sync-button">
+<div class="btn sauce-sync-button" title="Sauce Activity Sync">
     <div class="sauce-sync-icon">
         {{=icon sync-alt-regular=}}
         {{=icon check-solid=}}


### PR DESCRIPTION
I couldn't figure out what the button does without clicking on it, while for I could hover all the Strava-native buttons next to it and figure out what they do.