### PR TITLE
Update dashboard feed selector to reflect Strava changes

### DIFF
--- a/src/site/dashboard.js
+++ b/src/site/dashboard.js
@@ -497,7 +497,7 @@ sauce.ns('dashboard', function(ns) {
 
 
     function load() {
-        const feedSelector = 'main .feed-ui';
+        const feedSelector = 'main .feature-feed';
         const feedEl = document.querySelector(feedSelector);
         if (!feedEl) {
             const mo = new MutationObserver(() => {


### PR DESCRIPTION
Strava has updated the CSS class for its main feed from `feed-ui` to `feature-feed`. This change updates the selector accordingly.

I'm not sure if backwards compatibility is needed. If so, I can update the selector to handle both cases.

Tested with a local build in a Chromium browser.

Resolves #236.